### PR TITLE
Customize window level 

### DIFF
--- a/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMRenderingWindowHelper.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMRenderingWindowHelper.m
@@ -37,7 +37,8 @@
 #if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     }
 #endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-    UIWindowForModal.windowLevel = UIWindowLevelNormal;
+      // NOTE: iPad で Keyboard accessory view が前面に表示されてしまうため window level をカスタマイズ
+      UIWindowForModal.windowLevel = UIWindowLevelStatusBar;
   });
   return UIWindowForModal;
 }
@@ -57,7 +58,8 @@
 #if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     }
 #endif
-    UIWindowForBanner.windowLevel = UIWindowLevelNormal;
+      // NOTE: iPad で Keyboard accessory view が前面に表示されてしまうため window level をカスタマイズ
+      UIWindowForBanner.windowLevel = UIWindowLevelStatusBar;
   });
 
   return UIWindowForBanner;

--- a/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMRenderingWindowHelper.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMRenderingWindowHelper.m
@@ -37,8 +37,8 @@
 #if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     }
 #endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-      // NOTE: iPad で Keyboard accessory view が前面に表示されてしまうため window level をカスタマイズ
-      UIWindowForModal.windowLevel = UIWindowLevelStatusBar;
+    // NOTE: iPad で Keyboard accessory view が前面に表示されてしまうため window level をカスタマイズ
+    UIWindowForModal.windowLevel = UIWindowLevelStatusBar;
   });
   return UIWindowForModal;
 }
@@ -58,8 +58,8 @@
 #if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     }
 #endif
-      // NOTE: iPad で Keyboard accessory view が前面に表示されてしまうため window level をカスタマイズ
-      UIWindowForBanner.windowLevel = UIWindowLevelStatusBar;
+    // NOTE: iPad で Keyboard accessory view が前面に表示されてしまうため window level をカスタマイズ
+    UIWindowForBanner.windowLevel = UIWindowLevelStatusBar;
   });
 
   return UIWindowForBanner;


### PR DESCRIPTION
### 変更点

iPad で Keyboard accessory view が前面に表示されてしまうため window level をカスタマイズ

https://github.com/chatwork/firebase-ios-sdk/commit/566dbe48c70b7c31f2eeb730b9f313dde02eea86 と同様の変更を v10.24.0 に対して実施